### PR TITLE
Update README.md

### DIFF
--- a/apps/android_rpc/README.md
+++ b/apps/android_rpc/README.md
@@ -29,7 +29,7 @@ dependencies {
 Now use Gradle to compile JNI, resolve Java dependencies and build the Android application together with tvm4j. Run following script to generate the apk file.
 
 ```bash
-export ANDROID_HOME=[Path to your Android SDK, e.g., ~/Android/sdk]
+export ANDROID_HOME=[Path to your Android SDK, e.g., ~/Android/sdk/ndk-bundle]
 cd apps/android_rpc
 gradle clean build
 ```


### PR DESCRIPTION
I think ANDROID_HOME and android sdk is ambiguous.

This is my file tree:
```
.
├── Android
│   └── sdk
│       └── ndk-bundle
```
 
Since `~/Android/sdk` is exactly my android sdk path, I have spent half a day to debug environment problem. 

Then I `export ANDROID_HOME=~/Android/sdk/ndk-bundle`, everything goes on well ...
